### PR TITLE
feat: add UIKit and AppKit implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,76 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+.swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# macOS
+.DS_Store 

--- a/ISK Example.xcodeproj/project.pbxproj
+++ b/ISK Example.xcodeproj/project.pbxproj
@@ -9,7 +9,11 @@
 /* Begin PBXBuildFile section */
 		873DB4322C9F07BE00FE8EE4 /* BasicImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873DB4312C9F07BE00FE8EE4 /* BasicImplementation.swift */; };
 		873DB4342C9F087900FE8EE4 /* CustomizedImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873DB4332C9F087900FE8EE4 /* CustomizedImplementation.swift */; };
-		879284822CA0141A00AE0C9A /* InfinityScrollKit in Frameworks */ = {isa = PBXBuildFile; productRef = 879284812CA0141A00AE0C9A /* InfinityScrollKit */; };
+		876BF0622DC634DE009DCD64 /* InfinityScrollKit in Frameworks */ = {isa = PBXBuildFile; productRef = 876BF0612DC634DE009DCD64 /* InfinityScrollKit */; };
+		876BF0652DC634F7009DCD64 /* InfinityScrollKit in Frameworks */ = {isa = PBXBuildFile; productRef = 876BF0642DC634F7009DCD64 /* InfinityScrollKit */; };
+		876BF0682DC64F6D009DCD64 /* UIKitImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876BF0672DC64F44009DCD64 /* UIKitImplementation.swift */; };
+		876BF06B2DCA7EA5009DCD64 /* AppKitImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876BF06A2DCA7E95009DCD64 /* AppKitImplementation.swift */; };
+		879FD9842DCAB1DA00813562 /* InfinityScrollKit in Frameworks */ = {isa = PBXBuildFile; productRef = 879FD9832DCAB1DA00813562 /* InfinityScrollKit */; };
 		87A2C9772C983C35005E8921 /* ISK_ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2C9762C983C35005E8921 /* ISK_ExampleApp.swift */; };
 		87A2C9792C983C35005E8921 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2C9782C983C35005E8921 /* ContentView.swift */; };
 		87A2C97B2C983C36005E8921 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 87A2C97A2C983C36005E8921 /* Assets.xcassets */; };
@@ -19,6 +23,8 @@
 /* Begin PBXFileReference section */
 		873DB4312C9F07BE00FE8EE4 /* BasicImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicImplementation.swift; sourceTree = "<group>"; };
 		873DB4332C9F087900FE8EE4 /* CustomizedImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizedImplementation.swift; sourceTree = "<group>"; };
+		876BF0672DC64F44009DCD64 /* UIKitImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitImplementation.swift; sourceTree = "<group>"; };
+		876BF06A2DCA7E95009DCD64 /* AppKitImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitImplementation.swift; sourceTree = "<group>"; };
 		8792847F2CA0098A00AE0C9A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		87A2C9732C983C35005E8921 /* ISK Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ISK Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		87A2C9762C983C35005E8921 /* ISK_ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISK_ExampleApp.swift; sourceTree = "<group>"; };
@@ -33,7 +39,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				879284822CA0141A00AE0C9A /* InfinityScrollKit in Frameworks */,
+				876BF0652DC634F7009DCD64 /* InfinityScrollKit in Frameworks */,
+				876BF0622DC634DE009DCD64 /* InfinityScrollKit in Frameworks */,
+				879FD9842DCAB1DA00813562 /* InfinityScrollKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -47,6 +55,22 @@
 				873DB4332C9F087900FE8EE4 /* CustomizedImplementation.swift */,
 			);
 			path = InfiniteScrollView;
+			sourceTree = "<group>";
+		};
+		876BF0662DC64F31009DCD64 /* UIInfiniteScrollView */ = {
+			isa = PBXGroup;
+			children = (
+				876BF0672DC64F44009DCD64 /* UIKitImplementation.swift */,
+			);
+			path = UIInfiniteScrollView;
+			sourceTree = "<group>";
+		};
+		876BF0692DCA7E82009DCD64 /* NSInfiniteScrollView */ = {
+			isa = PBXGroup;
+			children = (
+				876BF06A2DCA7E95009DCD64 /* AppKitImplementation.swift */,
+			);
+			path = NSInfiniteScrollView;
 			sourceTree = "<group>";
 		};
 		87A2C96A2C983C35005E8921 = {
@@ -72,6 +96,8 @@
 				87A2C9762C983C35005E8921 /* ISK_ExampleApp.swift */,
 				87A2C9782C983C35005E8921 /* ContentView.swift */,
 				873DB4302C9F076E00FE8EE4 /* InfiniteScrollView */,
+				876BF0662DC64F31009DCD64 /* UIInfiniteScrollView */,
+				876BF0692DCA7E82009DCD64 /* NSInfiniteScrollView */,
 				87A2C97A2C983C36005E8921 /* Assets.xcassets */,
 				87A2C97C2C983C36005E8921 /* ISK_Example.entitlements */,
 				87A2C97D2C983C36005E8921 /* Preview Content */,
@@ -104,7 +130,9 @@
 			);
 			name = "ISK Example";
 			packageProductDependencies = (
-				879284812CA0141A00AE0C9A /* InfinityScrollKit */,
+				876BF0612DC634DE009DCD64 /* InfinityScrollKit */,
+				876BF0642DC634F7009DCD64 /* InfinityScrollKit */,
+				879FD9832DCAB1DA00813562 /* InfinityScrollKit */,
 			);
 			productName = "ISK Example";
 			productReference = 87A2C9732C983C35005E8921 /* ISK Example.app */;
@@ -135,7 +163,7 @@
 			);
 			mainGroup = 87A2C96A2C983C35005E8921;
 			packageReferences = (
-				879284802CA0141A00AE0C9A /* XCRemoteSwiftPackageReference "InfinityScrollKit" */,
+				879FD9822DCAB1DA00813562 /* XCRemoteSwiftPackageReference "InfinityScrollKit" */,
 			);
 			productRefGroup = 87A2C9742C983C35005E8921 /* Products */;
 			projectDirPath = "";
@@ -164,8 +192,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				87A2C9792C983C35005E8921 /* ContentView.swift in Sources */,
+				876BF0682DC64F6D009DCD64 /* UIKitImplementation.swift in Sources */,
 				873DB4322C9F07BE00FE8EE4 /* BasicImplementation.swift in Sources */,
 				873DB4342C9F087900FE8EE4 /* CustomizedImplementation.swift in Sources */,
+				876BF06B2DCA7EA5009DCD64 /* AppKitImplementation.swift in Sources */,
 				87A2C9772C983C35005E8921 /* ISK_ExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -294,7 +324,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "ISK Example/ISK_Example.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"ISK Example/Preview Content\"";
 				DEVELOPMENT_TEAM = D652685959;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -310,7 +340,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
@@ -318,10 +348,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pierrejanineh.ISK-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -332,7 +363,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "ISK Example/ISK_Example.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"ISK Example/Preview Content\"";
 				DEVELOPMENT_TEAM = D652685959;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -348,7 +379,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
@@ -356,10 +387,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pierrejanineh.ISK-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};
@@ -387,20 +419,28 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		879284802CA0141A00AE0C9A /* XCRemoteSwiftPackageReference "InfinityScrollKit" */ = {
+		879FD9822DCAB1DA00813562 /* XCRemoteSwiftPackageReference "InfinityScrollKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/PierreJanineh-com/InfinityScrollKit";
+			repositoryURL = "https://github.com/PierreJanineh-com/InfinityScrollKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.1;
+				minimumVersion = 1.0.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		879284812CA0141A00AE0C9A /* InfinityScrollKit */ = {
+		876BF0612DC634DE009DCD64 /* InfinityScrollKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 879284802CA0141A00AE0C9A /* XCRemoteSwiftPackageReference "InfinityScrollKit" */;
+			productName = InfinityScrollKit;
+		};
+		876BF0642DC634F7009DCD64 /* InfinityScrollKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = InfinityScrollKit;
+		};
+		879FD9832DCAB1DA00813562 /* InfinityScrollKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 879FD9822DCAB1DA00813562 /* XCRemoteSwiftPackageReference "InfinityScrollKit" */;
 			productName = InfinityScrollKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ISK Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ISK Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "55db1dd7471597d31498f598948a1174cf9efafd7946ae1bfc7472d9c22274b7",
+  "originHash" : "49e8e303e4b93437d244b26d15ad51610d42da11d788e86a88679dcaea6d35e1",
   "pins" : [
     {
       "identity" : "infinityscrollkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/PierreJanineh-com/InfinityScrollKit",
+      "location" : "https://github.com/PierreJanineh-com/InfinityScrollKit.git",
       "state" : {
-        "revision" : "9105838047262dff0c2573bba3a7c40d93f10ff8",
-        "version" : "1.0.2"
+        "revision" : "71c02447155413890bf22d11c484ea914efb2e76",
+        "version" : "1.0.6"
       }
     }
   ],

--- a/ISK Example/ContentView.swift
+++ b/ISK Example/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import InfinityScrollKit
 
 struct ContentView: View {
     
@@ -21,23 +20,31 @@ struct ContentView: View {
     
     var body: some View {
         VStack {
-            Text("Basic implementation")
+            TitleText("Basic implementation")
             BasicImplementation(arr: arr)
             
             Divider()
             
-            Text("Customized implementation")
+            TitleText("Customized implementation")
             CustomizedImplementation()
+			
+			// Uncomment to test on iOS
+//			TitleText("UIKit implementation")
+//			UIKitImplementation()
+			
+			// Uncomment to test on macOS
+//			TitleText("AppKit implementation")
+//			AppKitImplementation()
         }
     }
+	
+	private func TitleText(_ string: String) -> Text {
+		Text(string)
+			.font(.title3)
+			.fontWeight(.medium)
+	}
 }
 
 #Preview {
     ContentView()
-}
-
-extension String: @retroactive Identifiable {
-    public var id: String {
-        self
-    }
 }

--- a/ISK Example/InfiniteScrollView/BasicImplementation.swift
+++ b/ISK Example/InfiniteScrollView/BasicImplementation.swift
@@ -9,11 +9,11 @@ import SwiftUI
 import InfinityScrollKit
 
 struct BasicImplementation: View {
-    let arr: [String]
+    @State var arr: [String] = []
     
     var body: some View {
-        InfiniteScrollView/*<String, Text, EmptyView, EmptyView>*/(
-            arr: arr,
+        InfiniteScrollView(
+            arr: $arr,
             options: .init(countPerPage: 5)
         ) { item in
             Text(item)
@@ -25,4 +25,11 @@ struct BasicImplementation: View {
 
 #Preview {
     BasicImplementation(arr: [])
+}
+
+// Objects passed to the arr property need to conform to Identifiable
+extension String: @retroactive Identifiable {
+	public var id: String {
+		self
+	}
 }

--- a/ISK Example/InfiniteScrollView/CustomizedImplementation.swift
+++ b/ISK Example/InfiniteScrollView/CustomizedImplementation.swift
@@ -9,12 +9,12 @@ import SwiftUI
 import InfinityScrollKit
 
 struct CustomizedImplementation: View {
-    @State private var arr: [String] = []
+    @State private var arr: [Person] = []
     @State private var isLoading: Bool = false
     
     var body: some View {
-        InfiniteScrollView/*<String, Text, ProgressView, EmptyView>*/(
-            arr: arr,
+        InfiniteScrollView(
+            arr: $arr,
             options: options,
             onLoadingChanged: onLoadingChanged,
             cellView: CellView,
@@ -23,18 +23,19 @@ struct CustomizedImplementation: View {
         )
     }
     
-    private var options: Options<String> {
+    private var options: Options<Person> {
         .init(
             orientation: .horizontal,
             countPerPage: 2,
             paginationOptions: .init(
-                concatMode: .auto, //.auto for automatically adding pages to the array instead of passing the full array everytime.
+                concatMode: .manual, // manual for manually appending items to the array and returning the whole array
                 onPageLoad: {
                     // Simulate an http request
                     try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
                     
+                    var arr = await arr
                     for i in arr.count...arr.count + 10 {
-                        arr.append("Cell #\(i)")
+                        arr.append(.init(name: "Cell #\(i)"))
                     }
                     return arr
                 },
@@ -42,8 +43,9 @@ struct CustomizedImplementation: View {
                     // Simulate an http request
                     try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
                     
+                    var arr = await arr
                     for i in 0...25 {
-                        arr.append("Cell #\(i)")
+                        arr.append(.init(name: "Cell #\(i)"))
                     }
                     return arr
                 }
@@ -59,20 +61,25 @@ struct CustomizedImplementation: View {
         }
     }
     
-    @ViewBuilder func CellView(_ item: String) -> some View {
-        Text(item)
+	@ViewBuilder func CellView(_ item: Person) -> some View {
+		Text(item.name)
     }
     
-    @ViewBuilder func LastCellView() -> some View {
+    @ViewBuilder private func LastCellView() -> some View {
         ProgressView()
             .padding()
     }
     
-    @ViewBuilder func EmptyArrView() -> some View {
+    @ViewBuilder private func EmptyArrView() -> some View {
         Text("No items to display...")
     }
 }
 
 #Preview {
     CustomizedImplementation()
+}
+
+struct Person: Identifiable, Hashable {
+    let name: String
+    let id: UUID = UUID()
 }

--- a/ISK Example/NSInfiniteScrollView/AppKitImplementation.swift
+++ b/ISK Example/NSInfiniteScrollView/AppKitImplementation.swift
@@ -1,0 +1,61 @@
+//
+//  AppKitImplementation.swift
+//  ISK Example
+//
+//  Created by Pierre Janineh on 06/05/2025.
+//
+
+#if os(macOS)
+import SwiftUI
+import InfinityScrollKit
+
+/// Dummy SwiftUI wrapper for the UIKit.
+struct AppKitImplementation: NSViewRepresentable {
+	private var infiniteScroll: NSInfiniteScrollView<Person, Self> = .init(items: [])
+	private var persons: [Person] { infiniteScroll.items }
+	
+	func makeNSView(context: Context) -> NSInfiniteScrollView<Person, Self> {
+		infiniteScroll.options = .init(
+			orientation: .vertical,
+			countPerPage: 2,
+			paginationOptions: .init(
+				concatMode: .manual, // manual for manually appending items to the array and returning the whole array
+				onPageLoad: {
+					// Simulate an http request
+					try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+					
+					var arr = await persons
+					for i in arr.count...arr.count + 10 {
+						arr.append(.init(name: "Cell #\(i)"))
+					}
+					return arr
+				},
+				onRefresh: {
+					// Simulate an http request
+					try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+					
+					var arr = await persons
+					for i in 0...25 {
+						arr.append(.init(name: "Cell #\(i)"))
+					}
+					return arr
+				}
+			)
+		)
+		infiniteScroll.delegate = self
+		return infiniteScroll
+	}
+	
+	func updateNSView(
+		_ uiView: NSInfiniteScrollView<Person, Self>, context: Context
+	) { }
+}
+
+extension AppKitImplementation: NSInfiniteScrollViewDelegate {
+	func cellFor(_ item: Person, at: IndexPath.Index) -> NSView {
+		let label = NSTextField(labelWithString: item.name)
+		label.alignment = .center
+		return label
+	}
+}
+#endif

--- a/ISK Example/UIInfiniteScrollView/UIKitImplementation.swift
+++ b/ISK Example/UIInfiniteScrollView/UIKitImplementation.swift
@@ -1,0 +1,60 @@
+//
+//  UIKitImplementation.swift
+//  ISK Example
+//
+//  Created by Pierre Janineh on 03/05/2025.
+//
+#if !os(macOS)
+import SwiftUI
+import InfinityScrollKit
+
+/// Dummy SwiftUI wrapper for the UIKit.
+struct UIKitImplementation: UIViewRepresentable {
+	private var infiniteScroll: UIInfiniteScrollView<Person, Self> = .init(items: [])
+	private var persons: [Person] { infiniteScroll.items }
+	
+	func makeUIView(context: Context) -> UIInfiniteScrollView<Person, Self> {
+		infiniteScroll.options = .init(
+			orientation: .vertical,
+			countPerPage: 2,
+			paginationOptions: .init(
+				concatMode: .manual, // manual for manually appending items to the array and returning the whole array
+				onPageLoad: {
+					// Simulate an http request
+					try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+					
+					var arr = await persons
+					for i in arr.count...arr.count + 10 {
+						arr.append(.init(name: "Cell #\(i)"))
+					}
+					return arr
+				},
+				onRefresh: {
+					// Simulate an http request
+					try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+					
+					var arr = await persons
+					for i in 0...25 {
+						arr.append(.init(name: "Cell #\(i)"))
+					}
+					return arr
+				}
+			)
+		)
+		infiniteScroll.delegate = self
+		return infiniteScroll
+	}
+
+	func updateUIView(
+		_ uiView: UIInfiniteScrollView<Person, Self>, context: Context
+	) { }
+}
+
+extension UIKitImplementation: UIInfiniteScrollViewDelegate {
+	func cellFor(_ item: Person, at: IndexPath.Index) -> UIView {
+		let label = UILabel()
+		label.text = item.name
+		return label
+	}
+}
+#endif


### PR DESCRIPTION
- Add UIKit and AppKit infinite scroll view implementations
- Update ContentView to support new implementations
- Add .gitignore for Xcode project configuration
- Update project configuration and dependencies
- Modify existing SwiftUI implementations for consistency

This commit adds cross-platform support for the infinite scroll view implementation, allowing the library to be used in UIKit and AppKit projects alongside SwiftUI.